### PR TITLE
Add Max Line Length Rule Enhancements and Tests

### DIFF
--- a/data/MaxLineLengthLongDocBlockClass.php
+++ b/data/MaxLineLengthLongDocBlockClass.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App;
+
+/**
+ * This is a very long docblock comment that definitely exceeds the eighty character maximum line length limit.
+ * And here is another very long line in the docblock that also exceeds the eighty character limit significantly.
+ */
+class MaxLineLengthLongDocBlockClass
+{
+    public function shortMethod(): void
+    {
+        $variable = 'short';
+    }
+
+    /**
+     * This method has a very long docblock description that definitely exceeds the eighty character maximum line length.
+     */
+    public function methodWithVeryLongLineInsideThatDefinitelyExceedsTheEightyCharacterMaximumLineLengthLimit(): void
+    {
+        $thisVariableNameIsAlsoExtremelyLongAndWillDefinitelyExceedTheMaximumLineLengthLimitOf80Characters = true;
+    }
+}
+

--- a/data/MaxLineLengthLongNamespaceClass.php
+++ b/data/MaxLineLengthLongNamespaceClass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Some\Very\Long\Namespace\That\Definitely\Exceeds\Eighty\Characters\And\Goes\On\Forever;
+
+class MaxLineLengthLongNamespaceClass
+{
+    public function shortMethod(): void
+    {
+        $variable = 'short';
+    }
+
+    public function methodWithVeryLongLineInsideThatDefinitelyExceedsTheEightyCharacterMaximumLineLengthLimit(): void
+    {
+        $thisVariableNameIsAlsoExtremelyLongAndWillDefinitelyExceedTheMaximumLineLengthLimitOf80Characters = true;
+    }
+}
+

--- a/docs/rules/Max-Line-Length-Rule.md
+++ b/docs/rules/Max-Line-Length-Rule.md
@@ -1,8 +1,10 @@
 # Max Line Length Rule
 
-Checks that lines do not exceed a specified maximum length. Provides options to exclude files by pattern and ignore use statements.
+Checks that lines do not exceed a specified maximum length. Provides options to exclude files by pattern and ignore specific types of lines (use statements, namespace declarations, docblocks).
 
-## Configuration Example
+## Configuration Examples
+
+### Using the new array API (recommended)
 
 ```neon
     -
@@ -11,13 +13,59 @@ Checks that lines do not exceed a specified maximum length. Provides options to 
             maxLineLength: 80
             excludePatterns: ['/.*\.generated\.php$/', '/.*vendor.*/']
             ignoreUseStatements: false
+            ignoreLineTypes:
+                useStatements: true
+                namespaceDeclaration: true
+                docBlocks: true
+        tags:
+            - phpstan.rules.rule
+```
+
+### Using the legacy parameter (backward compatible)
+
+```neon
+    -
+        class: Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule
+        arguments:
+            maxLineLength: 80
+            excludePatterns: []
+            ignoreUseStatements: true
         tags:
             - phpstan.rules.rule
 ```
 
 ## Parameters
 
-- `maxLineLength`: Maximum allowed line length in characters (default: 80).
-- `excludePatterns`: Array of regex patterns to exclude files from checking (optional).
-- `ignoreUseStatements`: Whether to ignore use statement lines (default: false).
+- `maxLineLength`: Maximum allowed line length in characters (required).
+- `excludePatterns`: Array of regex patterns to exclude files from checking (optional, default: `[]`).
+- `ignoreUseStatements`: Whether to ignore use statement lines (optional, default: `false`). **Note:** This parameter is maintained for backward compatibility. When set to `true`, it takes precedence over the `ignoreLineTypes` array.
+- `ignoreLineTypes`: Array of line types to ignore when checking line length (optional, default: `[]`). Available options:
+  - `useStatements`: Ignore lines containing `use` statements
+  - `namespaceDeclaration`: Ignore lines containing `namespace` declarations
+  - `docBlocks`: Ignore lines that are part of docblock comments (`/** ... */`)
 
+## Examples
+
+### Ignore only use statements
+
+```neon
+ignoreLineTypes:
+    useStatements: true
+```
+
+### Ignore namespace declarations and docblocks
+
+```neon
+ignoreLineTypes:
+    namespaceDeclaration: true
+    docBlocks: true
+```
+
+### Ignore all supported line types
+
+```neon
+ignoreLineTypes:
+    useStatements: true
+    namespaceDeclaration: true
+    docBlocks: true
+```

--- a/tests/TestCases/CleanCode/MaxLineLengthRuleArrayApiTest.php
+++ b/tests/TestCases/CleanCode/MaxLineLengthRuleArrayApiTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test the new array API for ignore options
+ * 
+ * @extends RuleTestCase<MaxLineLengthRule>
+ */
+class MaxLineLengthRuleArrayApiTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // Use the new array API to ignore use statements via the array
+        return new MaxLineLengthRule(80, [], false, ['useStatements' => true]);
+    }
+
+    /**
+     * Test that the new array API works for useStatements
+     */
+    public function testArrayApiForUseStatements(): void
+    {
+        // Lines 5, 6, 7 have use statements that exceed 80 characters - should be ignored
+        // Line 16 has a method signature that exceeds 80 characters - should be detected
+        // Line 18 has a variable assignment that exceeds 80 characters - should be detected
+        $this->analyse([__DIR__ . '/../../../data/MaxLineLengthLongUseStatementsClass.php'], [
+            [
+                'Line 16 exceeds the maximum length of 80 characters (found 117 characters).',
+                16,
+            ],
+            [
+                'Line 18 exceeds the maximum length of 80 characters (found 114 characters).',
+                18,
+            ],
+        ]);
+    }
+}
+

--- a/tests/TestCases/CleanCode/MaxLineLengthRuleBackwardCompatibilityTest.php
+++ b/tests/TestCases/CleanCode/MaxLineLengthRuleBackwardCompatibilityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test backward compatibility: ignoreUseStatements parameter still works
+ * 
+ * @extends RuleTestCase<MaxLineLengthRule>
+ */
+class MaxLineLengthRuleBackwardCompatibilityTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // Use the old API: 3rd parameter for ignoreUseStatements
+        return new MaxLineLengthRule(80, [], true);
+    }
+
+    /**
+     * Test that the old ignoreUseStatements parameter still works (backward compatibility)
+     */
+    public function testBackwardCompatibilityWithOldIgnoreUseStatementsParameter(): void
+    {
+        // Lines 5, 6, 7 have use statements that exceed 80 characters - should be ignored (BC)
+        // Line 16 has a method signature that exceeds 80 characters - should be detected
+        // Line 18 has a variable assignment that exceeds 80 characters - should be detected
+        $this->analyse([__DIR__ . '/../../../data/MaxLineLengthLongUseStatementsClass.php'], [
+            [
+                'Line 16 exceeds the maximum length of 80 characters (found 117 characters).',
+                16,
+            ],
+            [
+                'Line 18 exceeds the maximum length of 80 characters (found 114 characters).',
+                18,
+            ],
+        ]);
+    }
+}
+

--- a/tests/TestCases/CleanCode/MaxLineLengthRuleDetectDocBlockLongLinesTest.php
+++ b/tests/TestCases/CleanCode/MaxLineLengthRuleDetectDocBlockLongLinesTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test that long docblock lines ARE detected when ignoreDocBlocks is false
+ * 
+ * @extends RuleTestCase<MaxLineLengthRule>
+ */
+class MaxLineLengthRuleDetectDocBlockLongLinesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // Do NOT ignore docblocks (docBlocks is false/default)
+        return new MaxLineLengthRule(80, [], false, ['docBlocks' => false]);
+    }
+
+    /**
+     * Test that long docblock lines ARE detected when ignoreDocBlocks is false
+     */
+    public function testLongDocBlockLinesAreDetectedWhenNotIgnored(): void
+    {
+        // Line 6 has a long docblock line - should be detected
+        // Line 7 has a long docblock line - should be detected
+        // Line 17 has a long docblock line - should be detected
+        // Line 19 has a method signature that exceeds 80 characters - should be detected
+        // Line 21 has a variable assignment that exceeds 80 characters - should be detected
+        $this->analyse([__DIR__ . '/../../../data/MaxLineLengthLongDocBlockClass.php'], [
+            [
+                'Line 6 exceeds the maximum length of 80 characters (found 111 characters).',
+                6,
+            ],
+            [
+                'Line 7 exceeds the maximum length of 80 characters (found 113 characters).',
+                7,
+            ],
+            [
+                'Line 17 exceeds the maximum length of 80 characters (found 121 characters).',
+                17,
+            ],
+            [
+                'Line 19 exceeds the maximum length of 80 characters (found 117 characters).',
+                19,
+            ],
+            [
+                'Line 21 exceeds the maximum length of 80 characters (found 114 characters).',
+                21,
+            ],
+        ]);
+    }
+}
+

--- a/tests/TestCases/CleanCode/MaxLineLengthRuleDetectNamespaceLongLinesTest.php
+++ b/tests/TestCases/CleanCode/MaxLineLengthRuleDetectNamespaceLongLinesTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test that long namespace declarations ARE detected when ignoreNamespaces is false
+ * 
+ * @extends RuleTestCase<MaxLineLengthRule>
+ */
+class MaxLineLengthRuleDetectNamespaceLongLinesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // Do NOT ignore namespaces (namespaceDeclaration is false/default)
+        return new MaxLineLengthRule(80, [], false, ['namespaceDeclaration' => false]);
+    }
+
+    /**
+     * Test that long namespace declarations ARE detected when ignoreNamespaces is false
+     */
+    public function testLongNamespacesAreDetectedWhenNotIgnored(): void
+    {
+        // Line 3 has namespace that exceeds 80 characters - should be detected
+        // Line 12 has a method signature that exceeds 80 characters - should be detected
+        // Line 14 has a variable assignment that exceeds 80 characters - should be detected
+        $this->analyse([__DIR__ . '/../../../data/MaxLineLengthLongNamespaceClass.php'], [
+            [
+                'Line 3 exceeds the maximum length of 80 characters (found 101 characters).',
+                3,
+            ],
+            [
+                'Line 12 exceeds the maximum length of 80 characters (found 117 characters).',
+                12,
+            ],
+            [
+                'Line 14 exceeds the maximum length of 80 characters (found 114 characters).',
+                14,
+            ],
+        ]);
+    }
+}
+

--- a/tests/TestCases/CleanCode/MaxLineLengthRuleIgnoreDocBlockLongLinesTest.php
+++ b/tests/TestCases/CleanCode/MaxLineLengthRuleIgnoreDocBlockLongLinesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test that long docblock lines are ignored when ignoreDocBlocks is true
+ *
+ * @extends RuleTestCase<MaxLineLengthRule>
+ */
+class MaxLineLengthRuleIgnoreDocBlockLongLinesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // Ignore docblocks (docBlocks is true)
+        return new MaxLineLengthRule(80, [], false, ['docBlocks' => true]);
+    }
+
+    /**
+     * Test that long docblock lines are ignored when ignoreDocBlocks is true,
+     * but other long lines are still detected.
+     */
+    public function testLongDocBlockLinesAreIgnoredButOtherLongLinesAreDetected(): void
+    {
+        // Lines 6, 7, 17 have long docblock lines - should be ignored
+        // Line 19 has a method signature that exceeds 80 characters - should be detected
+        // Line 21 has a variable assignment that exceeds 80 characters - should be detected
+        $this->analyse([__DIR__ . '/../../../data/MaxLineLengthLongDocBlockClass.php'], [
+            [
+                'Line 19 exceeds the maximum length of 80 characters (found 117 characters).',
+                19,
+            ],
+            [
+                'Line 21 exceeds the maximum length of 80 characters (found 114 characters).',
+                21,
+            ],
+        ]);
+    }
+}

--- a/tests/TestCases/CleanCode/MaxLineLengthRuleIgnoreNamespaceLongLinesTest.php
+++ b/tests/TestCases/CleanCode/MaxLineLengthRuleIgnoreNamespaceLongLinesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\MaxLineLengthRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test that long namespace declarations are ignored when ignoreNamespaces is true
+ *
+ * @extends RuleTestCase<MaxLineLengthRule>
+ */
+class MaxLineLengthRuleIgnoreNamespaceLongLinesTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        // Ignore namespaces (namespaceDeclaration is true)
+        return new MaxLineLengthRule(80, [], false, ['namespaceDeclaration' => true]);
+    }
+
+    /**
+     * Test that long namespace declarations are ignored when ignoreNamespaces is true,
+     * but other long lines are still detected.
+     */
+    public function testLongNamespacesAreIgnoredButOtherLongLinesAreDetected(): void
+    {
+        // Line 3 has namespace that exceeds 80 characters - should be ignored
+        // Line 12 has a method signature that exceeds 80 characters - should be detected
+        // Line 14 has a variable assignment that exceeds 80 characters - should be detected
+        $this->analyse([__DIR__ . '/../../../data/MaxLineLengthLongNamespaceClass.php'], [
+            [
+                'Line 12 exceeds the maximum length of 80 characters (found 117 characters).',
+                12,
+            ],
+            [
+                'Line 14 exceeds the maximum length of 80 characters (found 114 characters).',
+                14,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
- Introduced new options for ignoring specific line types (use statements, namespace declarations, docblocks) in the Max Line Length Rule.
- Updated the rule implementation to handle these new options effectively.
- Added multiple test cases to ensure proper functionality of the new features, including backward compatibility for the ignoreUseStatements parameter.
- Created tests to validate detection and ignoring of long lines in docblocks and namespaces based on the new configuration options.