### PR TITLE
Add allowedDependencies feature to override forbidden dependencies

### DIFF
--- a/data/ForbiddenDependenciesAllowed/AllowedOverride.php
+++ b/data/ForbiddenDependenciesAllowed/AllowedOverride.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Capability\Billing\Domain;
+
+// These are forbidden by the "forbid everything" pattern but allowed by the whitelist
+use App\Shared\ValueObject\Money;
+use App\Capability\UserManagement\UserManagementFacade;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Test class that uses dependencies which are forbidden but overridden by allowedDependencies.
+ * None of these should trigger errors because they match the allowed patterns.
+ */
+class AllowedOverride
+{
+    private Money $amount;
+
+    private LoggerInterface $logger;
+
+    public function __construct(Money $amount, LoggerInterface $logger)
+    {
+        $this->amount = $amount;
+        $this->logger = $logger;
+    }
+
+    public function getFacade(): UserManagementFacade
+    {
+        return new \App\Capability\UserManagement\UserManagementFacade();
+    }
+
+    public function logSomething(): void
+    {
+        $this->logger->info('test');
+    }
+}

--- a/data/ForbiddenDependenciesAllowed/StillForbidden.php
+++ b/data/ForbiddenDependenciesAllowed/StillForbidden.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Capability\Billing\Domain;
+
+// These are forbidden and NOT in the allowed list - should trigger errors
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Test class that uses dependencies which are forbidden and NOT overridden.
+ * These should trigger errors.
+ */
+class StillForbidden
+{
+    private EntityManager $entityManager;
+
+    public function __construct(EntityManager $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function handleRequest(Request $request): void
+    {
+        // Using forbidden dependency
+    }
+
+    public function createEntityManager(): EntityManager
+    {
+        return new \Doctrine\ORM\EntityManager();
+    }
+}

--- a/tests/TestCases/Architecture/ForbiddenDependenciesAllowedTest.php
+++ b/tests/TestCases/Architecture/ForbiddenDependenciesAllowedTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\Architecture;
+
+use Phauthentic\PHPStanRules\Architecture\ForbiddenDependenciesRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * Test allowedDependencies feature that overrides forbidden dependencies
+ *
+ * @extends RuleTestCase<ForbiddenDependenciesRule>
+ */
+class ForbiddenDependenciesAllowedTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenDependenciesRule(
+            // Forbid everything (any namespaced class)
+            [
+                '/^App\\\\Capability\\\\.*\\\\Domain$/' => [
+                    '/.*\\\\.*/'  // Match anything with a backslash (namespaced)
+                ]
+            ],
+            true, // Enable FQCN checking
+            [     // All reference types (default)
+                'new',
+                'param',
+                'return',
+                'property',
+                'static_call',
+                'static_property',
+                'class_const',
+                'instanceof',
+                'catch',
+                'extends',
+                'implements',
+            ],
+            // Allow specific namespaces as override
+            [
+                '/^App\\\\Capability\\\\.*\\\\Domain$/' => [
+                    '/^App\\\\Shared\\\\/',
+                    '/^App\\\\Capability\\\\/',
+                    '/^Psr\\\\/'
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Test that allowed dependencies do not trigger errors
+     */
+    public function testAllowedDependenciesOverrideForbidden(): void
+    {
+        // Should have no errors - all dependencies match allowed patterns
+        $this->analyse([__DIR__ . '/../../../data/ForbiddenDependenciesAllowed/AllowedOverride.php'], []);
+    }
+
+    /**
+     * Test that forbidden dependencies not in allowed list still trigger errors
+     */
+    public function testForbiddenDependenciesStillReportErrors(): void
+    {
+        $this->analyse([__DIR__ . '/../../../data/ForbiddenDependenciesAllowed/StillForbidden.php'], [
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Doctrine\ORM\EntityManager`.',
+                8,
+            ],
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Symfony\Component\HttpFoundation\Request`.',
+                9,
+            ],
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Doctrine\ORM\EntityManager`.',
+                17,
+            ],
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Doctrine\ORM\EntityManager`.',
+                19,
+            ],
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Symfony\Component\HttpFoundation\Request`.',
+                24,
+            ],
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Doctrine\ORM\EntityManager`.',
+                29,
+            ],
+            [
+                'Forbidden dependency: A class in namespace `App\Capability\Billing\Domain` is not allowed to depend on `Doctrine\ORM\EntityManager`.',
+                31,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
- Introduced new classes `AllowedOverride` and `StillForbidden` to demonstrate the functionality of overriding forbidden dependencies with a whitelist.
- Updated `ForbiddenDependenciesRule` to include an `allowedDependencies` parameter, allowing specific dependencies to bypass the forbidden rules.
- Enhanced documentation for the `Dependency-Constraints-Rule` to explain the new `allowedDependencies` feature.
- Added tests to validate the behavior of allowed dependencies and ensure that forbidden dependencies still trigger errors when not in the allowed list.