### PR TITLE
Adding more Rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ See individual rule documentation for detailed configuration examples. A [full c
 - [Classname Must Match Pattern Rule](docs/rules/Classname-Must-Match-Pattern-Rule.md)
 - [Dependency Constraints Rule](docs/rules/Dependency-Constraints-Rule.md) *(deprecated, use Forbidden Dependencies Rule)*
 - [Forbidden Accessors Rule](docs/rules/Forbidden-Accessors-Rule.md)
+- [Forbidden Business Logic Rule](docs/rules/Forbidden-Business-Logic-Rule.md)
 - [Forbidden Dependencies Rule](docs/rules/Forbidden-Dependencies-Rule.md)
+- [Forbidden Date Time Comparison Rule](docs/rules/Forbidden-Date-Time-Comparison-Rule.md)
 - [Forbidden Namespaces Rule](docs/rules/Forbidden-Namespaces-Rule.md)
 - [Forbidden Static Methods Rule](docs/rules/Forbidden-Static-Methods-Rule.md)
 - [Method Must Return Type Rule](docs/rules/Method-Must-Return-Type-Rule.md)
@@ -39,6 +41,7 @@ See individual rule documentation for detailed configuration examples. A [full c
 ### Clean Code Rules
 
 - [Control Structure Nesting Rule](docs/rules/Control-Structure-Nesting-Rule.md)
+- [Forbidden Else Statements Rule](docs/rules/Forbidden-Else-Statements-Rule.md)
 - [Too Many Arguments Rule](docs/rules/Too-Many-Arguments-Rule.md)
 - [Max Line Length Rule](docs/rules/Max-Line-Length-Rule.md)
 
@@ -50,7 +53,7 @@ The rules in this package can be extended at project level to create self-docume
 
 A lot of the rules use regex patterns to match things. Many people are not good at writing them but thankfully there is AI today.
 
-If you struggle to write the regex patterns you need, you can use AI tools like [ChatGPT](https://chat.openai.com/) to help you generate them. Just describe what you want to match, and it can provide you with a regex pattern that fits your needs.  The regex can be tested using online tools like [regex101](https://regex101.com/).
+If you struggle to write the regex patterns you need, you can use AI agents to help you generate them. Just describe what you want to match, and it can provide you with a regex pattern that fits your needs.  The regex can be tested using online tools like [regex101](https://regex101.com/).
 
 ## Why PHPStan to enforce Architectural Rules?
 

--- a/data/ForbiddenBusinessLogicRule/EmptyGlobalFixture.php
+++ b/data/ForbiddenBusinessLogicRule/EmptyGlobalFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ForbiddenBusinessLogicRule;
+
+final class EmptyGlobalFixture
+{
+    public function onlyIf(): void
+    {
+        if (true) {
+        }
+    }
+
+    public function unmatchedHasIf(): void
+    {
+        if (true) {
+        }
+    }
+}

--- a/data/ForbiddenBusinessLogicRule/MinimalDefaults.php
+++ b/data/ForbiddenBusinessLogicRule/MinimalDefaults.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ForbiddenBusinessLogicRule;
+
+final class MinimalDefaults
+{
+    public function m(): void
+    {
+        if (true) {
+        }
+    }
+}

--- a/data/ForbiddenBusinessLogicRule/ScenarioFixture.php
+++ b/data/ForbiddenBusinessLogicRule/ScenarioFixture.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ForbiddenBusinessLogicRule;
+
+/**
+ * Fixture for ForbiddenBusinessLogicRuleTest.
+ */
+final class ScenarioFixture
+{
+    public function onlyGlobalMatch(): void
+    {
+        if (true) {
+        }
+    }
+
+    public function onlyIf(): void
+    {
+        if (true) {
+        }
+        foreach ([] as $_) {
+        }
+    }
+
+    public function noOverrideX(): void
+    {
+        if (true) {
+        }
+    }
+
+    public function lastWinsM(): void
+    {
+        if (true) {
+        }
+        for ($i = 0; $i < 1; $i++) {
+        }
+        switch (1) {
+            default:
+                break;
+        }
+    }
+
+    public function unknownNamesN(): void
+    {
+        if (true) {
+        }
+        foreach ([] as $_) {
+        }
+    }
+}

--- a/data/ForbiddenDateTimeComparison/GlobalFunctionViolations.php
+++ b/data/ForbiddenDateTimeComparison/GlobalFunctionViolations.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ForbiddenDateTimeComparison;
+
+use DateTimeInterface;
+
+function global_datetime_compare(DateTimeInterface $left, DateTimeInterface $right): bool
+{
+    return $left === $right;
+}

--- a/data/ForbiddenDateTimeComparison/GlobalViolations.php
+++ b/data/ForbiddenDateTimeComparison/GlobalViolations.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ForbiddenDateTimeComparison;
+
+use DateTimeInterface;
+
+final class GlobalViolations
+{
+    public function identicalDates(DateTimeInterface $a, DateTimeInterface $b): bool
+    {
+        return $a === $b;
+    }
+
+    public function notIdenticalDates(DateTimeInterface $a, DateTimeInterface $b): bool
+    {
+        return $a !== $b;
+    }
+
+    public function looseOk(DateTimeInterface $a, DateTimeInterface $b): bool
+    {
+        return $a == $b;
+    }
+
+    public function mixedWithObject(object $a, DateTimeInterface $b): bool
+    {
+        return $a === $b;
+    }
+}

--- a/data/ForbiddenDateTimeComparison/ScopedViolations.php
+++ b/data/ForbiddenDateTimeComparison/ScopedViolations.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ForbiddenDateTimeComparison;
+
+use DateTimeInterface;
+
+final class ScopedViolations
+{
+    public function matchedMethod(DateTimeInterface $a, DateTimeInterface $b): bool
+    {
+        return $a === $b;
+    }
+
+    public function unmatchedMethod(DateTimeInterface $a, DateTimeInterface $b): bool
+    {
+        return $a === $b;
+    }
+}

--- a/data/ForbiddenElseStatementsRuleFixture.php
+++ b/data/ForbiddenElseStatementsRuleFixture.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ElseRules;
+
+class Matched
+{
+    public function matchedMethod(bool $x): void
+    {
+        if ($x) {
+            return;
+        } else {
+            return;
+        }
+    }
+
+    public function anotherMatched(bool $x): void
+    {
+        if ($x) {
+            return;
+        } else {
+            return;
+        }
+    }
+}
+
+class Unmatched
+{
+    public function any(bool $x): void
+    {
+        if ($x) {
+            return;
+        } else {
+            return;
+        }
+    }
+}

--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -22,11 +22,23 @@ Forbids public and/or protected getters and setters on classes matching specifie
 
 See [Forbidden Accessors Rule documentation](rules/Forbidden-Accessors-Rule.md) for detailed information.
 
+## Forbidden Business Logic Rule
+
+Forbids configured control structures (`if`, `for`, `foreach`, `while`, `switch`) inside class methods. A global `forbiddenStatements` list applies to all such methods; optional `patterns` (regex on `Fqcn::methodName`) may supply `forbiddenStatements` per match, which replace the effective list for that method (last matching override wins).
+
+See [Forbidden Business Logic Rule documentation](rules/Forbidden-Business-Logic-Rule.md) for detailed information.
+
 ## Forbidden Dependencies Rule
 
 Enforces dependency constraints between namespaces by checking `use` statements and optionally fully qualified class names (FQCNs). This rule prevents classes in one namespace from depending on classes in another, helping enforce architectural boundaries like layer separation.
 
 See [Forbidden Dependencies Rule documentation](rules/Forbidden-Dependencies-Rule.md) for detailed information.
+
+## Forbidden Date Time Comparison Rule
+
+Forbids `===` and `!==` when both sides are definitely `DateTimeInterface`, because strict equality is object identity, not same instant. Optional `patterns` (regex on `Fqcn::methodName`) limit the rule to matching class methods; an empty `patterns` list applies globally (unlike Forbidden Else Statements Rule, where empty `patterns` disables the rule).
+
+See [Forbidden Date Time Comparison Rule documentation](rules/Forbidden-Date-Time-Comparison-Rule.md) for detailed information.
 
 ## Forbidden Static Methods Rule
 
@@ -39,6 +51,12 @@ See [Forbidden Static Methods Rule documentation](rules/Forbidden-Static-Methods
 Ensures that classes matching specified patterns have properties with expected names, types, and visibility scopes. Can optionally enforce that matching classes must have certain properties.
 
 See [Property Must Match Rule documentation](rules/Property-Must-Match-Rule.md) for detailed information.
+
+## Forbidden Else Statements Rule
+
+Forbids plain `else` in class methods whose `Full\Class\Name::methodName` matches any configured regex, using the same `Fqcn::methodName` convention as other method-scoped rules. Empty `patterns` disables the rule.
+
+See [Forbidden Else Statements Rule documentation](rules/Forbidden-Else-Statements-Rule.md) for detailed information.
 
 ## Full Configuration Example
 
@@ -246,6 +264,25 @@ services:
         tags:
             - phpstan.rules.rule
 
+    # Forbid selected control structures (global + optional per-regex overrides)
+    -
+        class: Phauthentic\PHPStanRules\Architecture\ForbiddenBusinessLogicRule
+        arguments:
+            forbiddenStatements:
+                - if
+                - for
+                - foreach
+                - while
+                - switch
+            patterns:
+                -
+                    pattern: '/^App\\Capability\\.*\\Domain\\.*::/'
+                    forbiddenStatements:
+                        - if
+                        - switch
+        tags:
+            - phpstan.rules.rule
+
     # Forbid accessors on domain entities
     -
         class: Phauthentic\PHPStanRules\Architecture\ForbiddenAccessorsRule
@@ -266,6 +303,15 @@ services:
         class: Phauthentic\PHPStanRules\CleanCode\ControlStructureNestingRule
         arguments:
             maxNestingLevel: 3
+        tags:
+            - phpstan.rules.rule
+
+    # Forbid else in selected class methods (regex on Fqcn::methodName)
+    -
+        class: Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule
+        arguments:
+            patterns:
+                - '/^App\\Capability\\.*\\Presentation\\Http\\.*Controller::(handle|__invoke)$/'
         tags:
             - phpstan.rules.rule
 ```

--- a/docs/rules/Forbidden-Business-Logic-Rule.md
+++ b/docs/rules/Forbidden-Business-Logic-Rule.md
@@ -1,0 +1,55 @@
+# Forbidden Business Logic Rule
+
+Forbids selected imperative control structures inside class methods: `if`, `for`, `foreach`, `while`, and `switch`. Typical use cases include pushing branching and iteration behind domain objects or policy objects in specific layers.
+
+The rule evaluates the current scope as `Full\Class\Name::methodName` (from PHPStan’s class and function reflections). Anonymous functions and global functions are out of scope when the class or function reflection is missing.
+
+## Global list and per-pattern overrides
+
+- **`forbiddenStatements`**: Default set of construct names to forbid in every class method. Names are case-insensitive. Unknown names are ignored. If this list is empty, nothing is forbidden unless a matching pattern entry supplies a non-empty `forbiddenStatements` list.
+- **`patterns`**: Ordered list of entries. Each entry has a **`pattern`** (regex matched against `Fqcn::methodName`). Optionally **`forbiddenStatements`**: if present on an entry whose pattern matches, it **replaces** the effective forbidden list entirely for that method. If several entries match, the **last** matching entry that defines `forbiddenStatements` wins. Entries that match but omit `forbiddenStatements` do not change the effective list (it stays as set by global and earlier matches).
+
+The default constructor uses all five constructs globally and an empty `patterns` list, which forbids those constructs everywhere in class methods.
+
+## Legacy `patterns` format
+
+You may pass plain regex strings; each is normalised to `{ pattern: "..." }` without an override, so only the global list applies for methods that do not receive a later matching override with `forbiddenStatements`.
+
+## Configuration Example
+
+```neon
+    -
+        class: Phauthentic\PHPStanRules\Architecture\ForbiddenBusinessLogicRule
+        arguments:
+            forbiddenStatements:
+                - if
+                - for
+                - foreach
+                - while
+                - switch
+            patterns:
+                -
+                    pattern: '/^App\\\\Domain\\\\.*::/'
+                    forbiddenStatements:
+                        - if
+                        - switch
+                -
+                    pattern: '/^App\\\\Application\\\\.*Workflow::run$/'
+                    forbiddenStatements:
+                        - foreach
+        tags:
+            - phpstan.rules.rule
+```
+
+## Parameters
+
+- `forbiddenStatements` (`list<string>`): Global list of forbidden construct names: `if`, `for`, `foreach`, `while`, `switch`.
+- `patterns` (`list<array{pattern: string, forbiddenStatements?: list<string>}> | list<string>`): Regex entries against `Fqcn::methodName`, optionally with per-entry `forbiddenStatements` that replace the effective list when that pattern matches (last such match wins).
+
+## Class-wide patterns
+
+Match every method on a class with a regex on the `::` prefix, for example `/^App\\\\Module\\\\Foo::/` or `/^App\\\\Module\\\\Foo::.+$/`.
+
+## Ignoring violations
+
+Use PHPStan baseline or inline `@phpstan-ignore` with a short justification when a rare exception is required.

--- a/docs/rules/Forbidden-Date-Time-Comparison-Rule.md
+++ b/docs/rules/Forbidden-Date-Time-Comparison-Rule.md
@@ -1,0 +1,49 @@
+# Forbidden Date Time Comparison Rule
+
+Forbids strict identity comparisons (`===` and `!==`) when **both** operands are known to implement `DateTimeInterface`.
+
+## Why
+
+In PHP, `===` and `!==` on objects compare **identity** (same object instance in memory), not whether two values represent the **same point in time**. Two distinct `DateTimeImmutable` instances with the same instant still compare as not identical with `===`. That makes `===` / `!==` a frequent source of subtle bugs when the intent was to compare calendar instants.
+
+Loose equality (`==` / `!=`) for `DateTimeInterface` compares the dates for equality in the sense most callers expect. Alternatively, compare normalized instants explicitly (for example `getTimestamp()`, a canonical `format()`, or `DateTimeImmutable::createFromInterface()` followed by a defined comparison strategy).
+
+## Semantics of `patterns`
+
+Patterns use the same convention as other method-targeting rules in this package: each entry is a PCRE regex matched against **`Full\Class\Name::methodName`** (FQCN of the class, `::`, then the method name).
+
+- **`patterns` omitted or empty (`[]`):** the rule is **global**. Any `===` / `!==` between two definitely-`DateTimeInterface` operands is reported in **any** analyzed scope (class methods, namespaced functions, file-level code, and so on), wherever PHPStan can prove both types.
+
+- **`patterns` non-empty:** the rule runs **only inside class methods** where both the class and the enclosing function are known. The current method must match **at least one** pattern. Code outside a class method (for example a namespaced function) is **not** checked, because there is no `Fqcn::methodName` string in that form.
+
+This differs from the [Forbidden Else Statements Rule](Forbidden-Else-Statements-Rule.md): there, an empty `patterns` list **disables** the rule. Here, an empty list means **no scope filter** (apply everywhere).
+
+## Configuration example
+
+Global (entire codebase):
+
+```neon
+    -
+        class: Phauthentic\PHPStanRules\Architecture\ForbiddenDateTimeComparisonRule
+        arguments:
+            patterns: []
+        tags:
+            - phpstan.rules.rule
+```
+
+Scoped to specific methods (regex on `Fqcn::methodName`):
+
+```neon
+    -
+        class: Phauthentic\PHPStanRules\Architecture\ForbiddenDateTimeComparisonRule
+        arguments:
+            patterns:
+                - '/^App\\\\Presentation\\\\Http\\\\.*Controller::(handle|__invoke)$/'
+                - '/^App\\\\Module\\\\.*::execute$/'
+        tags:
+            - phpstan.rules.rule
+```
+
+## Parameters
+
+- `patterns`: List of PCRE regex strings. When empty, the rule applies globally. When non-empty, each pattern is matched against `Full\Class\Name::methodName` for the enclosing class method; the comparison is only checked if any pattern matches.

--- a/docs/rules/Forbidden-Else-Statements-Rule.md
+++ b/docs/rules/Forbidden-Else-Statements-Rule.md
@@ -1,0 +1,26 @@
+# Forbidden Else Statements Rule
+
+Forbids plain `else` branches in class methods whose `Full\Class\Name::methodName` matches any of the configured regex patterns. This matches the same targeting convention as rules such as **Method Must Return Type Rule** (`Fqcn::methodName` as a single string).
+
+`elseif` is not checked (it is a different AST node). Prefer early returns, guard clauses, or `elseif` where appropriate.
+
+If `patterns` is empty, the rule does nothing. If analysis is not inside a class method (no class or no enclosing function in scope), the rule does nothing—for example, `else` at file scope or in a global function is not matched.
+
+To apply the rule to every method on a class, use a regex prefix on the method side of `::`, for example `/^App\\Module\\Foo::/` or `/^App\\Module\\Foo::.+$/`.
+
+## Configuration Example
+
+```neon
+    -
+        class: Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule
+        arguments:
+            patterns:
+                - '/^App\\Presentation\\Http\\.*Controller::(handle|__invoke)$/'
+                - '/^App\\Module\\.*::execute$/'
+        tags:
+            - phpstan.rules.rule
+```
+
+## Parameters
+
+- `patterns`: List of PCRE regex strings. Each pattern is matched against `Full\Class\Name::methodName` for the enclosing method. If any pattern matches, an `else` in that method is reported.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,5 +2,6 @@ parameters:
     level: 8
     paths:
         - src
+        - tests
     parallel:
         maximumNumberOfProcesses: 8

--- a/rule-builder.html
+++ b/rule-builder.html
@@ -340,6 +340,7 @@
                             <option value="ClassnameMustMatchPatternRule">ClassnameMustMatchPatternRule</option>
                             <option value="ControlStructureNestingRule">ControlStructureNestingRule</option>
                             <option value="ForbiddenDependenciesRule">ForbiddenDependenciesRule</option>
+                            <option value="ForbiddenDateTimeComparisonRule">ForbiddenDateTimeComparisonRule</option>
                             <option value="ForbiddenAccessorsRule">ForbiddenAccessorsRule</option>
                             <option value="ForbiddenNamespacesRule">ForbiddenNamespacesRule</option>
                             <option value="MaxLineLengthRule">MaxLineLengthRule</option>
@@ -551,6 +552,20 @@
                         required: false,
                         help: 'Reference types to check when checkFqcn is enabled',
                         options: ['new', 'param', 'return', 'property', 'static_call', 'static_property', 'class_const', 'instanceof', 'catch', 'extends', 'implements'],
+                        default: []
+                    }
+                ]
+            },
+            ForbiddenDateTimeComparisonRule: {
+                description: 'Forbids === and !== between DateTimeInterface values (identity vs same instant). Optional patterns on Fqcn::methodName; empty patterns = global.',
+                class: 'Phauthentic\\PHPStanRules\\Architecture\\ForbiddenDateTimeComparisonRule',
+                fields: [
+                    {
+                        name: 'patterns',
+                        label: 'Method patterns (Fqcn::methodName)',
+                        type: 'array',
+                        required: false,
+                        help: 'PCRE regexes matched against Full\\Class\\Name::methodName. Leave empty for global (all code).',
                         default: []
                     }
                 ]
@@ -1719,10 +1734,12 @@
             yaml += `<span class="yaml-comment"># ${rule.description}</span>\n`;
             yaml += `<span class="yaml-key">-</span>\n`;
             yaml += `    <span class="yaml-key">class:</span> <span class="yaml-string">${rule.class}</span>\n`;
-            yaml += `    <span class="yaml-key">arguments:</span>\n`;
-
-            for (const [key, value] of Object.entries(data)) {
-                yaml += renderYamlValue(key, value, 8);
+            const dataKeys = Object.keys(data);
+            if (dataKeys.length > 0) {
+                yaml += `    <span class="yaml-key">arguments:</span>\n`;
+                for (const [key, value] of Object.entries(data)) {
+                    yaml += renderYamlValue(key, value, 8);
+                }
             }
 
             yaml += `    <span class="yaml-key">tags:</span>\n`;

--- a/src/Architecture/ForbiddenBusinessLogicRule.php
+++ b/src/Architecture/ForbiddenBusinessLogicRule.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE file
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * @author    Florian Krämer
+ * @link      https://github.com/Phauthentic
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Foreach_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\Switch_;
+use PhpParser\Node\Stmt\While_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Specification:
+ *
+ * - Forbids selected control structures inside class methods: if, for, foreach, while, switch.
+ * - Construct names are matched case-insensitively; unknown names in configuration are ignored.
+ * - Targeting uses `Full\Class\Name::methodName` from the current scope (class + function reflections).
+ *   If either reflection is missing, no errors are reported.
+ * - `forbiddenStatements` is the global default list. Every matching scope starts from this list.
+ * - `patterns` is a list of `pattern` (regex against `Fqcn::methodName`) and optional `forbiddenStatements`.
+ *   For each pattern entry in order: if the regex matches, and `forbiddenStatements` is present, it
+ *   replaces the effective list entirely. The last matching entry that defines `forbiddenStatements` wins.
+ *   Pattern entries without `forbiddenStatements` do not change the effective list.
+ * - If `forbiddenStatements` is empty, nothing is forbidden unless a matching pattern supplies a
+ *   non-empty `forbiddenStatements` list.
+ * - Legacy configuration: `patterns` may be a list of regex strings; each is normalised to
+ *   `{ pattern: string }` without overrides.
+ *
+ * @implements Rule<Node>
+ */
+class ForbiddenBusinessLogicRule implements Rule
+{
+    private const ERROR_MESSAGE = 'Statement "%s" is not allowed in this method.';
+
+    private const IDENTIFIER = 'phauthentic.architecture.forbiddenBusinessLogic';
+
+    /** @var list<string> */
+    private const DEFAULT_FORBIDDEN = ['if', 'for', 'foreach', 'while', 'switch'];
+
+    /**
+     * @var array<string, string> lowercase construct name => canonical name
+     */
+    private const KNOWN_CONSTRUCTS = [
+        'if' => 'if',
+        'for' => 'for',
+        'foreach' => 'foreach',
+        'while' => 'while',
+        'switch' => 'switch',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private array $globalForbiddenStatements;
+
+    /**
+     * @var list<array{pattern: string, forbiddenStatements?: list<string>}>
+     */
+    private array $patterns;
+
+    /**
+     * @param list<string> $forbiddenStatements
+     * @param array<int, mixed> $patterns Legacy string entries or arrays with `pattern` and optional `forbiddenStatements`.
+     */
+    public function __construct(
+        array $forbiddenStatements = self::DEFAULT_FORBIDDEN,
+        array $patterns = [],
+    ) {
+        $this->globalForbiddenStatements = $this->normalizeConstructNames($forbiddenStatements);
+        $this->patterns = $this->normalizePatterns($patterns);
+    }
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $construct = $this->nodeToConstructName($node);
+        if ($construct === null) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        $functionReflection = $scope->getFunction();
+        if ($classReflection === null || $functionReflection === null) {
+            return [];
+        }
+
+        $fullName = $classReflection->getName() . '::' . $functionReflection->getName();
+        $effective = $this->resolveForbiddenStatementsFor($fullName);
+        if ($effective === []) {
+            return [];
+        }
+
+        if (!in_array($construct, $effective, true)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $construct))
+                ->identifier(self::IDENTIFIER)
+                ->line($node->getLine())
+                ->build(),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveForbiddenStatementsFor(string $fullName): array
+    {
+        $effective = $this->globalForbiddenStatements;
+
+        foreach ($this->patterns as $entry) {
+            if (preg_match($entry['pattern'], $fullName) !== 1) {
+                continue;
+            }
+            if (array_key_exists('forbiddenStatements', $entry)) {
+                $effective = $this->normalizeConstructNames($entry['forbiddenStatements']);
+            }
+        }
+
+        return $effective;
+    }
+
+    /**
+     * @param list<string> $names
+     * @return list<string>
+     */
+    private function normalizeConstructNames(array $names): array
+    {
+        $out = [];
+        foreach ($names as $name) {
+            $key = strtolower($name);
+            if (!isset(self::KNOWN_CONSTRUCTS[$key])) {
+                continue;
+            }
+            $canonical = self::KNOWN_CONSTRUCTS[$key];
+            $out[$canonical] = $canonical;
+        }
+
+        return array_values($out);
+    }
+
+    /**
+     * @param array<int, mixed> $patterns
+     * @return list<array{pattern: string, forbiddenStatements?: list<string>}>
+     */
+    private function normalizePatterns(array $patterns): array
+    {
+        $out = [];
+        foreach ($patterns as $entry) {
+            if (is_string($entry)) {
+                $out[] = ['pattern' => $entry];
+                continue;
+            }
+            if (!is_array($entry)) {
+                continue;
+            }
+            $pattern = $entry['pattern'] ?? null;
+            if (!is_string($pattern)) {
+                continue;
+            }
+            /** @var array{pattern: string, forbiddenStatements?: list<string>} $normalized */
+            $normalized = ['pattern' => $pattern];
+            if (array_key_exists('forbiddenStatements', $entry)) {
+                $stmts = $entry['forbiddenStatements'];
+                if (is_array($stmts)) {
+                    /** @var list<string> $list */
+                    $list = $stmts;
+                    $normalized['forbiddenStatements'] = $list;
+                }
+            }
+            $out[] = $normalized;
+        }
+
+        return $out;
+    }
+
+    private function nodeToConstructName(Node $node): ?string
+    {
+        if ($node instanceof If_) {
+            return 'if';
+        }
+        if ($node instanceof For_) {
+            return 'for';
+        }
+        if ($node instanceof Foreach_) {
+            return 'foreach';
+        }
+        if ($node instanceof While_) {
+            return 'while';
+        }
+        if ($node instanceof Switch_) {
+            return 'switch';
+        }
+
+        return null;
+    }
+}

--- a/src/Architecture/ForbiddenDateTimeComparisonRule.php
+++ b/src/Architecture/ForbiddenDateTimeComparisonRule.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE file
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * @author    Florian Krämer
+ * @link      https://github.com/Phauthentic
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Architecture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Specification:
+ *
+ * - Reports `===` and `!==` when both operands are definitely `\DateTimeInterface` (identity
+ *   comparison does not mean the same instant).
+ * - If `patterns` is empty, the rule applies globally (any scope PHPStan analyzes).
+ * - If `patterns` is non-empty, only class methods whose `Full\Class\Name::methodName` matches
+ *   any pattern are checked (requires class and function reflections in scope).
+ * - Does not report other operators (e.g. `==`, `<=>`).
+ *
+ * Unlike {@see \Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule}, an empty `patterns` list does not disable this rule;
+ * it means “no scope filter” (global).
+ *
+ * @implements Rule<BinaryOp>
+ */
+class ForbiddenDateTimeComparisonRule implements Rule
+{
+    use ClassNameResolver;
+
+    private const IDENTIFIER = 'phauthentic.architecture.forbiddenDateTimeComparison';
+
+    private const ERROR_MESSAGE = 'Cannot compare DateTimeInterface values with %s: this compares object identity (whether both sides are the same in-memory PHP instance), not whether the two datetimes represent the same point in time. Use == / != for value comparison, or compare instants explicitly (e.g. getTimestamp(), format(), DateTimeImmutable::createFromInterface()).';
+
+    /**
+     * @param list<string> $patterns PCRE regexes matched against `Full\Class\Name::methodName`. Empty = global.
+     */
+    public function __construct(
+        private array $patterns = [],
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return BinaryOp::class;
+    }
+
+    /**
+     * @param BinaryOp $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (
+            !$node instanceof BinaryOp\Identical
+            && !$node instanceof BinaryOp\NotIdentical
+        ) {
+            return [];
+        }
+
+        if (!$this->shouldAnalyzeScope($scope)) {
+            return [];
+        }
+
+        $leftType = $scope->getType($node->left);
+        $rightType = $scope->getType($node->right);
+        $dateTimeType = new ObjectType(\DateTimeInterface::class);
+
+        if (
+            !$dateTimeType->isSuperTypeOf($leftType)->yes()
+            || !$dateTimeType->isSuperTypeOf($rightType)->yes()
+        ) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                self::ERROR_MESSAGE,
+                $node->getOperatorSigil()
+            ))
+                ->identifier(self::IDENTIFIER)
+                ->line($node->getLine())
+                ->build(),
+        ];
+    }
+
+    private function shouldAnalyzeScope(Scope $scope): bool
+    {
+        if ($this->patterns === []) {
+            return true;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        $functionReflection = $scope->getFunction();
+        if ($classReflection === null || $functionReflection === null) {
+            return false;
+        }
+
+        $fullName = $classReflection->getName() . '::' . $functionReflection->getName();
+
+        return $this->matchesAnyPattern($fullName, $this->patterns);
+    }
+}

--- a/src/Architecture/MethodSignatureMustMatchRule.php
+++ b/src/Architecture/MethodSignatureMustMatchRule.php
@@ -57,8 +57,8 @@ class MethodSignatureMustMatchRule implements Rule
      *     minParameters: null|int,
      *     maxParameters: null|int,
      *     signature: array<array{
-     *         type: string,
-     *         pattern: string|null,
+     *         type?: string,
+     *         pattern?: string|null,
      *     }>,
      *     visibilityScope?: string|null,
      *     required?: bool|null
@@ -125,7 +125,7 @@ class MethodSignatureMustMatchRule implements Rule
     }
 
     /**
-     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type: string, pattern: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
+     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type?: string, pattern?: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
      * @return list<IdentifierRuleError>
      */
     private function validateMethodAgainstConfig(ClassMethod $method, array $config, string $fullName): array
@@ -228,7 +228,7 @@ class MethodSignatureMustMatchRule implements Rule
     }
 
     /**
-     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type: string, pattern: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
+     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type?: string, pattern?: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
      */
     private function checkVisibility(array $config, ClassMethod $method, string $fullName): ?IdentifierRuleError
     {
@@ -255,7 +255,7 @@ class MethodSignatureMustMatchRule implements Rule
     }
 
     /**
-     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type: string, pattern: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
+     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type?: string, pattern?: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
      */
     private function checkMinParameters(array $config, int $paramCount, string $fullName, int $line): ?IdentifierRuleError
     {
@@ -270,7 +270,7 @@ class MethodSignatureMustMatchRule implements Rule
     }
 
     /**
-     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type: string, pattern: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
+     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type?: string, pattern?: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
      */
     private function checkMaxParameters(array $config, int $paramCount, string $fullName, int $line): ?IdentifierRuleError
     {
@@ -339,7 +339,7 @@ class MethodSignatureMustMatchRule implements Rule
     /**
      * Format the expected method signature for error messages.
      *
-     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type: string, pattern: string|null}>, visibilityScope?: string|null, required?: bool|null} $patternConfig
+     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type?: string, pattern?: string|null}>, visibilityScope?: string|null, required?: bool|null} $patternConfig
      */
     private function formatSignatureForError(array $patternConfig): string
     {
@@ -364,7 +364,7 @@ class MethodSignatureMustMatchRule implements Rule
         if (!empty($patternConfig['signature'])) {
             foreach ($patternConfig['signature'] as $i => $sig) {
                 $paramParts = [];
-                if ($sig['type'] !== '') {
+                if (($sig['type'] ?? '') !== '') {
                     $paramParts[] = $sig['type'];
                 }
                 $paramParts[] = '$param' . ($i + 1);
@@ -397,7 +397,7 @@ class MethodSignatureMustMatchRule implements Rule
     }
 
     /**
-     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type: string, pattern: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
+     * @param array{pattern: string, minParameters: int|null, maxParameters: int|null, signature: array<array{type?: string, pattern?: string|null}>, visibilityScope?: string|null, required?: bool|null} $config
      * @param array<string> $implementedMethods
      */
     private function checkRequiredMethod(array $config, string $className, array $implementedMethods, int $line): ?IdentifierRuleError

--- a/src/CleanCode/ForbiddenElseStatementsRule.php
+++ b/src/CleanCode/ForbiddenElseStatementsRule.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE file
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * @author    Florian Krämer
+ * @link      https://github.com/Phauthentic
+ * @license   https://opensource.org/licenses/MIT MIT License
+ */
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\CleanCode;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Else_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\ShouldNotHappenException;
+
+/**
+ * Specification:
+ *
+ * - Forbids plain `else` (not `elseif`) inside class methods when the enclosing
+ *   `Full\Class\Name::methodName` string matches any configured regex, using the
+ *   same convention as MethodMustReturnTypeRule.
+ * - If `patterns` is empty, the rule does nothing.
+ * - If the scope has no class or no enclosing function, the rule does nothing.
+ *
+ * @implements Rule<Else_>
+ */
+class ForbiddenElseStatementsRule implements Rule
+{
+    private const ERROR_MESSAGE = 'Else is not allowed in %s; prefer early returns or guard clauses.';
+
+    private const IDENTIFIER = 'phauthentic.cleancode.forbiddenElseStatements';
+
+    /**
+     * @param string[] $patterns Regex patterns matched against `Full\Class\Name::methodName`
+     */
+    public function __construct(
+        private array $patterns = [],
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Else_::class;
+    }
+
+    /**
+     * @param Else_ $node
+     * @return list<RuleError>
+     * @throws ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->patterns === []) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        $function = $scope->getFunction();
+        if ($classReflection === null || $function === null) {
+            return [];
+        }
+
+        $fullName = $classReflection->getName() . '::' . $function->getName();
+        if (!$this->matchesAnyPattern($fullName)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $fullName))
+                ->identifier(self::IDENTIFIER)
+                ->line($node->getLine())
+                ->build(),
+        ];
+    }
+
+    private function matchesAnyPattern(string $fullName): bool
+    {
+        foreach ($this->patterns as $pattern) {
+            if (preg_match($pattern, $fullName) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/TestCases/Architecture/ClassMustBeReadonlyRuleTest.php
+++ b/tests/TestCases/Architecture/ClassMustBeReadonlyRuleTest.php
@@ -8,11 +8,11 @@ use Phauthentic\PHPStanRules\Architecture\ClassMustBeReadonlyRule;
 use PHPStan\Testing\RuleTestCase;
 
 /**
- * @extends RuleTestCase<ClassMustBeReadonlyRuleTest>
+ * @extends RuleTestCase<ClassMustBeReadonlyRule>
  */
 class ClassMustBeReadonlyRuleTest extends RuleTestCase
 {
-    protected function getRule(): \PHPStan\Rules\Rule
+    protected function getRule(): ClassMustBeReadonlyRule
     {
         return new ClassMustBeReadonlyRule([
             '/Controller$/', // all classes that end with "Controller"

--- a/tests/TestCases/Architecture/ForbiddenBusinessLogicRuleDefaultsTest.php
+++ b/tests/TestCases/Architecture/ForbiddenBusinessLogicRuleDefaultsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\Architecture;
+
+use Phauthentic\PHPStanRules\Architecture\ForbiddenBusinessLogicRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenBusinessLogicRule>
+ */
+class ForbiddenBusinessLogicRuleDefaultsTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenBusinessLogicRule();
+    }
+
+    public function testDefaultConstructorForbidsAllFiveWithEmptyPatterns(): void
+    {
+        $this->analyse([__DIR__ . '/../../../data/ForbiddenBusinessLogicRule/MinimalDefaults.php'], [
+            [
+                'Statement "if" is not allowed in this method.',
+                11,
+            ],
+        ]);
+    }
+}

--- a/tests/TestCases/Architecture/ForbiddenBusinessLogicRuleEmptyGlobalTest.php
+++ b/tests/TestCases/Architecture/ForbiddenBusinessLogicRuleEmptyGlobalTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\Architecture;
+
+use Phauthentic\PHPStanRules\Architecture\ForbiddenBusinessLogicRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenBusinessLogicRule>
+ */
+class ForbiddenBusinessLogicRuleEmptyGlobalTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenBusinessLogicRule(
+            [],
+            [
+                ['pattern' => '/^App\\\\ForbiddenBusinessLogicRule\\\\EmptyGlobalFixture::onlyIf$/', 'forbiddenStatements' => ['if']],
+            ]
+        );
+    }
+
+    public function testEmptyGlobalUsesPatternOverrideOnly(): void
+    {
+        $this->analyse([__DIR__ . '/../../../data/ForbiddenBusinessLogicRule/EmptyGlobalFixture.php'], [
+            [
+                'Statement "if" is not allowed in this method.',
+                11,
+            ],
+        ]);
+    }
+}

--- a/tests/TestCases/Architecture/ForbiddenBusinessLogicRuleTest.php
+++ b/tests/TestCases/Architecture/ForbiddenBusinessLogicRuleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\Architecture;
+
+use Phauthentic\PHPStanRules\Architecture\ForbiddenBusinessLogicRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenBusinessLogicRule>
+ */
+class ForbiddenBusinessLogicRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ForbiddenBusinessLogicRule(
+            ['if', 'for', 'foreach', 'while', 'switch'],
+            [
+                ['pattern' => '/^App\\\\ForbiddenBusinessLogicRule\\\\ScenarioFixture::onlyIf$/', 'forbiddenStatements' => ['if']],
+                '/::noOverrideX$/',
+                ['pattern' => '/::unknownNamesN$/', 'forbiddenStatements' => ['bogus', 'if']],
+                ['pattern' => '/^App\\\\ForbiddenBusinessLogicRule\\\\ScenarioFixture::lastWins/', 'forbiddenStatements' => ['if', 'for']],
+                ['pattern' => '/^App\\\\ForbiddenBusinessLogicRule\\\\ScenarioFixture::lastWinsM$/', 'forbiddenStatements' => ['switch']],
+            ]
+        );
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/../../../data/ForbiddenBusinessLogicRule/ScenarioFixture.php'], [
+            [
+                'Statement "if" is not allowed in this method.',
+                14,
+            ],
+            [
+                'Statement "if" is not allowed in this method.',
+                20,
+            ],
+            [
+                'Statement "if" is not allowed in this method.',
+                28,
+            ],
+            [
+                'Statement "switch" is not allowed in this method.',
+                38,
+            ],
+            [
+                'Statement "if" is not allowed in this method.',
+                46,
+            ],
+        ]);
+    }
+}

--- a/tests/TestCases/Architecture/ForbiddenDateTimeComparisonRuleScopedTest.php
+++ b/tests/TestCases/Architecture/ForbiddenDateTimeComparisonRuleScopedTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\Architecture;
+
+use Phauthentic\PHPStanRules\Architecture\ForbiddenDateTimeComparisonRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenDateTimeComparisonRule>
+ */
+class ForbiddenDateTimeComparisonRuleScopedTest extends RuleTestCase
+{
+    private const MSG_IDENTICAL = 'Cannot compare DateTimeInterface values with ===: this compares object identity (whether both sides are the same in-memory PHP instance), not whether the two datetimes represent the same point in time. Use == / != for value comparison, or compare instants explicitly (e.g. getTimestamp(), format(), DateTimeImmutable::createFromInterface()).';
+
+    protected function getRule(): Rule
+    {
+        return new ForbiddenDateTimeComparisonRule([
+            '/^App\\\\ForbiddenDateTimeComparison\\\\ScopedViolations::matchedMethod$/',
+        ]);
+    }
+
+    public function testOnlyMatchedMethodReports(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../data/ForbiddenDateTimeComparison/ScopedViolations.php'],
+            [
+                [self::MSG_IDENTICAL, 13],
+            ]
+        );
+    }
+
+    public function testNamespacedFunctionSkippedWhenPatternsNonEmpty(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../data/ForbiddenDateTimeComparison/GlobalFunctionViolations.php'],
+            []
+        );
+    }
+}

--- a/tests/TestCases/Architecture/ForbiddenDateTimeComparisonRuleTest.php
+++ b/tests/TestCases/Architecture/ForbiddenDateTimeComparisonRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\Architecture;
+
+use Phauthentic\PHPStanRules\Architecture\ForbiddenDateTimeComparisonRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenDateTimeComparisonRule>
+ */
+class ForbiddenDateTimeComparisonRuleTest extends RuleTestCase
+{
+    /** Must match {@see ForbiddenDateTimeComparisonRule} output exactly for RuleTestCase. */
+    private const MSG_IDENTICAL = 'Cannot compare DateTimeInterface values with ===: this compares object identity (whether both sides are the same in-memory PHP instance), not whether the two datetimes represent the same point in time. Use == / != for value comparison, or compare instants explicitly (e.g. getTimestamp(), format(), DateTimeImmutable::createFromInterface()).';
+
+    /** @see self::MSG_IDENTICAL */
+    private const MSG_NOT_IDENTICAL = 'Cannot compare DateTimeInterface values with !==: this compares object identity (whether both sides are the same in-memory PHP instance), not whether the two datetimes represent the same point in time. Use == / != for value comparison, or compare instants explicitly (e.g. getTimestamp(), format(), DateTimeImmutable::createFromInterface()).';
+
+    protected function getRule(): Rule
+    {
+        return new ForbiddenDateTimeComparisonRule([]);
+    }
+
+    public function testGlobalReportsInClassMethods(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../data/ForbiddenDateTimeComparison/GlobalViolations.php'],
+            [
+                [self::MSG_IDENTICAL, 13],
+                [self::MSG_NOT_IDENTICAL, 18],
+            ]
+        );
+    }
+
+    public function testGlobalReportsOutsideClassMethods(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/../../../data/ForbiddenDateTimeComparison/GlobalFunctionViolations.php'],
+            [
+                [self::MSG_IDENTICAL, 11],
+            ]
+        );
+    }
+}

--- a/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleClassWideTest.php
+++ b/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleClassWideTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenElseStatementsRule>
+ */
+class ForbiddenElseStatementsRuleClassWideTest extends RuleTestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../data/ForbiddenElseStatementsRuleFixture.php';
+
+    protected function getRule(): Rule
+    {
+        return new ForbiddenElseStatementsRule([
+            '/^App\\\\ElseRules\\\\Matched::/',
+        ]);
+    }
+
+    public function testClassWidePatternMatchesAllMethodsOnClass(): void
+    {
+        $this->analyse([self::FIXTURE], [
+            [
+                'Else is not allowed in App\ElseRules\Matched::matchedMethod; prefer early returns or guard clauses.',
+                13,
+            ],
+            [
+                'Else is not allowed in App\ElseRules\Matched::anotherMatched; prefer early returns or guard clauses.',
+                22,
+            ],
+        ]);
+    }
+}

--- a/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleEmptyPatternsTest.php
+++ b/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleEmptyPatternsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenElseStatementsRule>
+ */
+class ForbiddenElseStatementsRuleEmptyPatternsTest extends RuleTestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../data/ForbiddenElseStatementsRuleFixture.php';
+
+    protected function getRule(): Rule
+    {
+        return new ForbiddenElseStatementsRule([]);
+    }
+
+    public function testEmptyPatternsIsNoOp(): void
+    {
+        $this->analyse([self::FIXTURE], []);
+    }
+}

--- a/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleNoMatchTest.php
+++ b/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleNoMatchTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenElseStatementsRule>
+ */
+class ForbiddenElseStatementsRuleNoMatchTest extends RuleTestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../data/ForbiddenElseStatementsRuleFixture.php';
+
+    protected function getRule(): Rule
+    {
+        return new ForbiddenElseStatementsRule([
+            '/^App\\\\ElseRules\\\\DoesNotExist::/',
+        ]);
+    }
+
+    public function testNoReportWhenPatternDoesNotMatch(): void
+    {
+        $this->analyse([self::FIXTURE], []);
+    }
+}

--- a/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleTest.php
+++ b/tests/TestCases/CleanCode/ForbiddenElseStatementsRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phauthentic\PHPStanRules\Tests\TestCases\CleanCode;
+
+use Phauthentic\PHPStanRules\CleanCode\ForbiddenElseStatementsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<ForbiddenElseStatementsRule>
+ */
+class ForbiddenElseStatementsRuleTest extends RuleTestCase
+{
+    private const FIXTURE = __DIR__ . '/../../../data/ForbiddenElseStatementsRuleFixture.php';
+
+    protected function getRule(): Rule
+    {
+        return new ForbiddenElseStatementsRule([
+            '/^App\\\\ElseRules\\\\Matched::matchedMethod$/',
+        ]);
+    }
+
+    public function testReportsElseWhenFqcnMethodMatches(): void
+    {
+        $this->analyse([self::FIXTURE], [
+            [
+                'Else is not allowed in App\ElseRules\Matched::matchedMethod; prefer early returns or guard clauses.',
+                13,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
- Added new rules: Forbidden Business Logic Rule and Forbidden Date Time Comparison Rule, which enforce architectural constraints in class methods.
- Updated phpstan.neon to include tests directory for analysis.
- Enhanced documentation for the new rules, including detailed descriptions and configuration examples in Rules.md and individual rule markdown files.
- Introduced tests for the new rules to ensure proper functionality and compliance with the defined constraints.

These changes improve the enforcement of architectural boundaries and provide clearer guidance for users.